### PR TITLE
Add UTC versions of isoDate and isoTime

### DIFF
--- a/dist/date.js
+++ b/dist/date.js
@@ -107,7 +107,9 @@
         mediumTime:     "h:MM:ss TT",
         longTime:       "h:MM:ss TT Z",
         isoDate:        "yyyy-mm-dd",
+        isoUtcDate:     "UTC:yyyy-mm-dd",
         isoTime:        "HH:MM:ss",
+        isoUtcTime:     "UTC:HH:MM:ss",
         isoDateTime:    "yyyy-mm-dd'T'HH:MM:ss",
         isoUtcDateTime: "UTC:yyyy-mm-dd'T'HH:MM:ss'Z'"
     };


### PR DESCRIPTION
As there is an isoUtcDateTime, why not have isoUtcDate and isoUtcTime.

I made this change because working with just Dates (time not relevant) in JS can be a hassle if someone views it in a different timezone. In my case we are talking about the day construction starts on a project which doesn't worry about timezones or time, so we want to always use the UTC time.

I use the isoUtcDate to standardize what everyone sees and I think it would be helpful for others to have as well, also it makes it a bit cleaner than having `.format("UTC:yyyy-mm-dd")` everywhere.

Also, thanks for the perfect, light Date library.
